### PR TITLE
Remove six

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ If you'd like to run the application without installing it, run `./run.py`.
 The project is written entierly in Python 3. There are no closed-source
 components in this project. It is fully hackable.
 
-The project is dependent on `python-mpv`, `requests`, `websocket_client`, `urllib3`, and `six`. There are no other
+The project is dependent on `python-mpv`, `requests`, `websocket_client`, and `urllib3`. There are no other
 external dependencies.
 
 This project is based Plex MPV Shim, which is based on https://github.com/wnielson/omplex, which
@@ -171,7 +171,7 @@ following these directions, please take care to ensure both the python
 and libmpv libraries are either 64 or 32 bit. (Don't mismatch them.)
 
 1. Install [Python3](https://www.python.org/downloads/) with PATH enabled. Install [7zip](https://ninite.com/7zip/).
-2. After installing python3, open `cmd` as admin and run `pip install --upgrade pyinstaller python-mpv requests websocket_client urllib3 six`.
+2. After installing python3, open `cmd` as admin and run `pip install --upgrade pyinstaller python-mpv requests websocket_client urllib`.
 3. Download [libmpv](https://sourceforge.net/projects/mpv-player-windows/files/libmpv/).
 4. Extract the `mpv-1.dll` from the file and move it to the `jellyfin-mpv-shim` folder.
 5. Open a regular `cmd` prompt. Navigate to the `jellyfin-mpv-shim` folder.

--- a/jellyfin_mpv_shim/jellyfin/http.py
+++ b/jellyfin_mpv_shim/jellyfin/http.py
@@ -8,7 +8,6 @@ import logging
 import time
 
 import requests
-from six import string_types
 
 from .exceptions import HTTPException
 
@@ -190,7 +189,7 @@ class HTTP(object):
             if isinstance(value, dict):
                 self._process_params(value)
 
-            if isinstance(value, string_types):
+            if isinstance(value, str):
                 params[key] = self._replace_user_info(value)
 
     def _get_header(self, data):

--- a/setup.py
+++ b/setup.py
@@ -25,5 +25,5 @@ setup(
         "Operating System :: OS Independent",
     ],
     python_requires='>=3.6',
-    install_requires=['python-mpv', 'requests', 'urllib3', 'six', 'websocket_client']
+    install_requires=['python-mpv', 'requests', 'urllib3', 'websocket_client']
 )


### PR DESCRIPTION
Removes six. There's no reason to use it when jellyfin-mpv-shim is a Python 3-only app.