### PR TITLE
Add direct paths support

### DIFF
--- a/jellyfin_mpv_shim/conf.py
+++ b/jellyfin_mpv_shim/conf.py
@@ -22,6 +22,7 @@ class Settings(object):
         "auto_play":            True,
         "idle_cmd":             None,
         "idle_cmd_delay":       60,
+        "direct_paths":         False,
         "always_transcode":     False,
         "transcode_h265":       False,
         "transcode_hi10p":      False,

--- a/jellyfin_mpv_shim/media.py
+++ b/jellyfin_mpv_shim/media.py
@@ -122,7 +122,10 @@ class Video(object):
             self.client.jellyfin.close_transcode(self.client.config.data["app.device_id"])
 
     def _get_url_from_source(self, source):
-        if self.media_source['SupportsDirectStream']:
+        if settings.direct_paths:
+            self.is_transcode = False
+            return self.media_source['Path']
+        elif self.media_source['SupportsDirectStream']:
             self.is_transcode = False
             return "%s/Videos/%s/stream?static=true&MediaSourceId=%s&api_key=%s" % (
                 self.client.config.data["auth.server"],


### PR DESCRIPTION
Since jellyfin/jellyfin#2295 is accepted, direct play over SMB/NFS can be used which is more reliable, consumes less memory and better experience overall (for me at least).