### PR TITLE
fixed URL rewrite only happening in remote_direct_paths 

### DIFF
--- a/jellyfin_mpv_shim/media.py
+++ b/jellyfin_mpv_shim/media.py
@@ -3,6 +3,7 @@ import uuid
 import urllib.parse
 import os.path
 import re 
+import pathlib
 from sys import platform
 
 from .conf import settings
@@ -140,11 +141,12 @@ class Video(object):
                 # if path is smb path in credential format for kodi and maybe linux \\username:password@mediaserver\foo, 
                 # translate it to mediaserver/foo 
                 if sys.platform.startswith("win32") or sys.platform.startswith("cygwin"):
-                    match = re.search('(?:(?:\\\\)|(?:\/\/)).+:.*@(.+)', self.media_source['Path'])
+                    # matches on SMB scheme
+                    match = re.search('(?:\\\\).+:.*@(.+)', self.media_source['Path'])
                     if match:
                         # replace forward slash to backward slashes
-                        return '\\\\' + match.groups()[0].replace('/', '\\')
-                return self.media_source['Path']
+                        return pathlib.Path('\\\\' + match.groups()[0]
+                return pathlib.Path(self.media_source['Path'])
             else:
                 # If there's no uri scheme, check if the file exixsts because it might not be mounted
                 if os.path.isfile(self.media_source['Path']):

--- a/jellyfin_mpv_shim/media.py
+++ b/jellyfin_mpv_shim/media.py
@@ -2,6 +2,8 @@ import logging
 import uuid
 import urllib.parse
 import os.path
+import re 
+from sys import platform
 
 from .conf import settings
 from .utils import is_local_domain, get_profile, get_seq
@@ -134,6 +136,14 @@ class Video(object):
             if urllib.parse.urlparse(self.media_source['Path']).scheme:
                 self.is_transcode = False
                 log.debug("Using remote direct path.")
+                # translate path for windows 
+                # if path is smb path in credential format for kodi and maybe linux \\username:password@mediaserver\foo, 
+                # translate it to mediaserver/foo 
+                if sys.platform.startswith("win32") or sys.platform.startswith("cygwin"):
+                    match = re.search('(?:(?:\\\\)|(?:\/\/)).+:.*@(.+)', self.media_source['Path'])
+                    if match:
+                        # replace forward slash to backward slashes
+                        return '\\\\' + match.groups()[0].replace('/', '\\')
                 return self.media_source['Path']
             else:
                 # If there's no uri scheme, check if the file exixsts because it might not be mounted

--- a/jellyfin_mpv_shim/media.py
+++ b/jellyfin_mpv_shim/media.py
@@ -134,18 +134,21 @@ class Video(object):
         # - If there's a scheme specified or the path exists as a local file.
         if ((self.media_source.get('Protocol') == "Http" or self.media_source['SupportsDirectPlay'])
             and settings.direct_paths and (settings.remote_direct_paths or self.parent.is_local)):
+
+            if platform.startswith("win32") or platform.startswith("cygwin"):
+                    # matches on SMB scheme
+                    match = re.search('(?:\\\\).+:.*@(.+)', self.media_source['Path'])
+                    if match:
+                        # replace forward slash to backward slashes
+                        log.debug("cleaned up credentials from path")
+                        self.media_source['Path'] = str(pathlib.Path('\\\\' + match.groups()[0]))
+
             if urllib.parse.urlparse(self.media_source['Path']).scheme:
                 self.is_transcode = False
                 log.debug("Using remote direct path.")
                 # translate path for windows 
                 # if path is smb path in credential format for kodi and maybe linux \\username:password@mediaserver\foo, 
                 # translate it to mediaserver/foo 
-                if sys.platform.startswith("win32") or sys.platform.startswith("cygwin"):
-                    # matches on SMB scheme
-                    match = re.search('(?:\\\\).+:.*@(.+)', self.media_source['Path'])
-                    if match:
-                        # replace forward slash to backward slashes
-                        return pathlib.Path('\\\\' + match.groups()[0]
                 return pathlib.Path(self.media_source['Path'])
             else:
                 # If there's no uri scheme, check if the file exixsts because it might not be mounted


### PR DESCRIPTION
Hi, I tested if #84 was merged correctly in the build and it seems that I wrote a bug. The regex parsing happens only in the remote direct path section of media.py. I put it in front of both local and remote direct path sections and it works now. 