### PR TITLE
update config to point to user's Library folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ on Linux or macOS from the terminal, the location of the config file will be pri
  - Windows - `%appdata%\jellyfin-mpv-shim\conf.json`
  - Linux - `~/.config/jellyfin-mpv-shim/conf.json`
  - Linux (Flatpak) - `~/.var/app/com.github.iwalton3.jellyfin-mpv-shim/config/jellyfin-mpv-shim/conf.json`
- - macOS - `Library/Application Support/jellyfin-mpv-shim/conf.json`
+ - macOS - `~/Library/Application Support/jellyfin-mpv-shim/conf.json`
  - CygWin - `~/.config/jellyfin-mpv-shim/conf.json`
 
 You can specify a custom configuration folder with the `--config` option.


### PR DESCRIPTION
more explicit that the config is in the user's `Library` folder, not the system's.
this gave me a moment of confusion while looking for the config json.